### PR TITLE
Extrae initialization and runtime hook for Distributed workflow

### DIFF
--- a/cfgs/distributed_calls.cfg
+++ b/cfgs/distributed_calls.cfg
@@ -1,0 +1,46 @@
+#ParaverCFG
+ConfigFile.Version: 3.4
+ConfigFile.NumWindows: 1
+ConfigFile.BeginDescription
+
+ConfigFile.EndDescription
+
+################################################################################
+< NEW DISPLAYING WINDOW Distributed runtime call >
+################################################################################
+window_name Distributed runtime call
+window_type single
+window_id 1
+window_position_x 395
+window_position_y 285
+window_width 600
+window_height 115
+window_comm_lines_enabled false
+window_flags_enabled false
+window_noncolor_mode true
+window_custom_color_enabled false
+window_semantic_scale_min_at_zero false
+window_logical_filtered true
+window_physical_filtered false
+window_comm_fromto true
+window_comm_tagsize true
+window_comm_typeval true
+window_units Microseconds
+window_maximum_y 9.000000000000
+window_minimum_y 0.000000000000
+window_compute_y_max false
+window_level thread
+window_scale_relative 1.000000000000
+window_end_time_relative 1.000000000000
+window_object appl { 1, { All } }
+window_begin_time_relative 0.000000000000
+window_open true
+window_drawmode draw_maximum
+window_drawmode_rows draw_maximum
+window_pixel_size 1
+window_labels_to_draw 1
+window_selected_functions { 14, { {cpu, Active Thd}, {appl, Adding}, {task, Adding}, {thread, Last Evt Val}, {node, Adding}, {system, Adding}, {workload, Adding}, {from_obj, All}, {to_obj, All}, {tag_msg, All}, {size_msg, All}, {bw_msg, All}, {evt_type, =}, {evt_value, All} } }
+window_compose_functions { 9, { {compose_cpu, As Is}, {compose_appl, As Is}, {compose_task, As Is}, {compose_thread, As Is}, {compose_node, As Is}, {compose_system, As Is}, {compose_workload, As Is}, {topcompose1, As Is}, {topcompose2, As Is} } }
+window_filter_module evt_type 1 400002
+window_filter_module evt_type_label 1 "Unknown"
+

--- a/cfgs/message_handling.cfg
+++ b/cfgs/message_handling.cfg
@@ -1,0 +1,45 @@
+#ParaverCFG
+ConfigFile.Version: 3.4
+ConfigFile.NumWindows: 1
+ConfigFile.BeginDescription
+
+ConfigFile.EndDescription
+
+################################################################################
+< NEW DISPLAYING WINDOW Message handling routines >
+################################################################################
+window_name Message handling routines
+window_type single
+window_id 1
+window_position_x 390
+window_position_y 826
+window_width 600
+window_height 115
+window_comm_lines_enabled false
+window_flags_enabled true
+window_noncolor_mode true
+window_custom_color_enabled false
+window_semantic_scale_min_at_zero false
+window_logical_filtered true
+window_physical_filtered false
+window_comm_fromto true
+window_comm_tagsize true
+window_comm_typeval true
+window_units Microseconds
+window_maximum_y 9.000000000000
+window_minimum_y 0.000000000000
+window_compute_y_max false
+window_level thread
+window_object appl { 1, { All } }
+window_begin_time 0.000000000000
+window_stop_time 44662903416.000000000000
+window_open true
+window_drawmode draw_maximum
+window_drawmode_rows draw_maximum
+window_pixel_size 1
+window_labels_to_draw 1
+window_selected_functions { 14, { {cpu, Active Thd}, {appl, Adding}, {task, Adding}, {thread, Last Evt Val}, {node, Adding}, {system, Adding}, {workload, Adding}, {from_obj, All}, {to_obj, All}, {tag_msg, All}, {size_msg, All}, {bw_msg, All}, {evt_type, =}, {evt_value, All} } }
+window_compose_functions { 9, { {compose_cpu, As Is}, {compose_appl, As Is}, {compose_task, As Is}, {compose_thread, As Is}, {compose_node, As Is}, {compose_system, As Is}, {compose_workload, As Is}, {topcompose1, As Is}, {topcompose2, As Is} } }
+window_filter_module evt_type 1 400004
+window_filter_module evt_type_label 1 "Unknown"
+

--- a/cfgs/workload_execution.cfg
+++ b/cfgs/workload_execution.cfg
@@ -1,0 +1,45 @@
+#ParaverCFG
+ConfigFile.Version: 3.4
+ConfigFile.NumWindows: 1
+ConfigFile.BeginDescription
+
+ConfigFile.EndDescription
+
+################################################################################
+< NEW DISPLAYING WINDOW Workload execution on workers >
+################################################################################
+window_name Workload execution on workers
+window_type single
+window_id 1
+window_position_x 390
+window_position_y 682
+window_width 600
+window_height 115
+window_comm_lines_enabled false
+window_flags_enabled true
+window_noncolor_mode true
+window_custom_color_enabled false
+window_semantic_scale_min_at_zero false
+window_logical_filtered true
+window_physical_filtered false
+window_comm_fromto true
+window_comm_tagsize true
+window_comm_typeval true
+window_units Microseconds
+window_maximum_y 1.000000000000
+window_minimum_y 0.000000000000
+window_compute_y_max false
+window_level thread
+window_object appl { 1, { All } }
+window_begin_time 0.000000000000
+window_stop_time 44662903416.000000000000
+window_open true
+window_drawmode draw_maximum
+window_drawmode_rows draw_maximum
+window_pixel_size 1
+window_labels_to_draw 1
+window_selected_functions { 14, { {cpu, Active Thd}, {appl, Adding}, {task, Adding}, {thread, Last Evt Val}, {node, Adding}, {system, Adding}, {workload, Adding}, {from_obj, All}, {to_obj, All}, {tag_msg, All}, {size_msg, All}, {bw_msg, All}, {evt_type, =}, {evt_value, All} } }
+window_compose_functions { 9, { {compose_cpu, As Is}, {compose_appl, As Is}, {compose_task, As Is}, {compose_thread, As Is}, {compose_node, As Is}, {compose_system, As Is}, {compose_workload, As Is}, {topcompose1, As Is}, {topcompose2, As Is} } }
+window_filter_module evt_type 1 400001
+window_filter_module evt_type_label 1 "Unknown"
+

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export EXTRAE_ON=1
+export EXTRAE_SKIP_AUTO_LIBRARY_INITIALIZE=1
+
+$*

--- a/scripts/julia2prv
+++ b/scripts/julia2prv
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+TRACE=$(mktemp -p .)
+
+trace_name=$1
+shift
+
+cat ${@} > ${TRACE} 
+mpi2prv -v -f ${TRACE} -o ${trace_name}
+rm $TRACE
+

--- a/scripts/test-distributed-work.jl
+++ b/scripts/test-distributed-work.jl
@@ -6,6 +6,8 @@ addprocs_extrae(1)
 @everywhere using Cassette
 @everywhere using Extrae
 
+# ENV["JULIA_DEBUG"] = Extrae
+# @everywhere ENV["JULIA_DEBUG"] = Extrae
 
 function random_sleep()
     println("Worker started: ", myid())

--- a/scripts/test-distributed-work.jl
+++ b/scripts/test-distributed-work.jl
@@ -15,9 +15,9 @@ end
 
 function test_distributed_work()
     @everywhere Extrae.init()
-    Cassette.overdub(Extrae.ExtraeCtx(), remote_do, Cassette.overdub, 2, Extrae.ExtraeCtx(), random_sleep)
-    # Cassette.overdub(Extrae.ExtraeCtx(), remote_do, Cassette.overdub, 3, Extrae.ExtraeCtx(), random_sleep)
-    # Cassette.overdub(Extrae.ExtraeCtx(), remote_do, Cassette.overdub, 4, Extrae.ExtraeCtx(), random_sleep)
+    Cassette.overdub(Extrae.ExtraeCtx(), remote_do, 2, random_sleep)
+    #Cassette.overdub(Extrae.ExtraeCtx(), remote_do, 3, random_sleep)
+    # Cassette.overdub(Extrae.ExtraeCtx(), remote_do, 4, random_sleep)
     sleep(10)
     @everywhere Extrae.finish()
 end

--- a/scripts/test-distributed-work.jl
+++ b/scripts/test-distributed-work.jl
@@ -13,15 +13,21 @@ function random_sleep()
     println("Worker woke up: ", myid())
 end
 
+@everywhere function matrix_multiply(A)
+    println("multiplying")
+    return A^2
+end
+
 function test_distributed_work()
-    @everywhere Extrae.init()
-    Cassette.overdub(Extrae.ExtraeCtx(), remote_do, 2, random_sleep)
-    #Cassette.overdub(Extrae.ExtraeCtx(), remote_do, 3, random_sleep)
-    # Cassette.overdub(Extrae.ExtraeCtx(), remote_do, 4, random_sleep)
-    sleep(10)
+
+    A = rand(1000, 1000)
+    a1 =  @spawnat :any matrix_multiply(A)
+    a2 = @spawnat :any matrix_multiply(A)
+    fetch(a1)
+    fetch(a2)
     @everywhere Extrae.finish()
 end
 
-test_distributed_work()
+Cassette.overdub(Extrae.ExtraeCtx(), test_distributed_work)
 
 println("END TEST")

--- a/src/API.jl
+++ b/src/API.jl
@@ -42,6 +42,7 @@ function init()
   @ccall setenv(var::Cstring, name::Cstring)::Cint
 
   FFI.Extrae_init()
+  Libc.flush_cstdio()
 end
 export init
 
@@ -59,7 +60,10 @@ export isinit
 
 Finalize the tracing library and dumps the intermediate tracing buffers onto disk.
 """
-finish() = FFI.Extrae_fini()
+function finish()
+  FFI.Extrae_fini()
+  Libc.flush_cstdio()
+end
 export finish
 
 """

--- a/src/API.jl
+++ b/src/API.jl
@@ -38,9 +38,7 @@ function init()
   #register(DistributedUsefulWorkEvent, "Workers workload execution")
 
   ## Setup traceid for not intereference
-  name = "JULIATRACE" * string(Distributed.myid())
-  var = "EXTRAE_PROGRAM_NAME"
-  @ccall setenv(var::Cstring, name::Cstring)::Cint
+  ENV["EXTRAE_PROGRAM_NAME"] = "JULIATRACE$(Distributed.myid())"
 
   FFI.Extrae_init()
   Libc.flush_cstdio()

--- a/src/API.jl
+++ b/src/API.jl
@@ -34,6 +34,8 @@ function init()
   ## Distributed functions to identify resources
   FFI.Extrae_set_numtasks_function(dist_numtasks)
   FFI.Extrae_set_taskid_function(dist_taskid)
+  #register(DistributedEvent, "Distributed runtime call")
+  #register(DistributedUsefulWorkEvent, "Workers workload execution")
 
   ## Setup traceid for not intereference
   name = "JULIATRACE" * string(Distributed.myid())
@@ -42,6 +44,9 @@ function init()
 
   FFI.Extrae_init()
   Libc.flush_cstdio()
+
+  println("Extrae initialized in worker $(myid())")
+
 end
 export init
 
@@ -97,6 +102,7 @@ description(::E) where {E<:Event} = description(E)
 Add a single timestampted event into the tracefile.
 """
 function emit(::Event{T,V}; counters::Bool=false) where {T,V}
+    println("Event emit: $(T): $(V)")
     if counters
         FFI.Extrae_eventandcounters(FFI.Type(T), FFI.Value(V))
     else

--- a/src/API.jl
+++ b/src/API.jl
@@ -43,7 +43,7 @@ function init()
   FFI.Extrae_init()
   Libc.flush_cstdio()
 
-  println("Extrae initialized in worker $(myid())")
+  @debug "Extrae initialized in worker $(myid())"
 
 end
 export init
@@ -100,7 +100,7 @@ description(::E) where {E<:Event} = description(E)
 Add a single timestampted event into the tracefile.
 """
 function emit(::Event{T,V}; counters::Bool=false) where {T,V}
-    println("Event emit: $(T): $(V)")
+    @debug "Event emit: $(T): $(V)"
     if counters
         FFI.Extrae_eventandcounters(FFI.Type(T), FFI.Value(V))
     else

--- a/src/API.jl
+++ b/src/API.jl
@@ -28,7 +28,21 @@ This routine is called automatically in different circumstances, which include:
 
 No major problems should occur if the library is initialized twice, only a warning appears in the terminal output noticing the intent of double initialization.
 """
-init() = FFI.Extrae_init()
+function init()
+
+  ## TODO: This setup should depend on isntrumentation options.
+  ## For example, if isntrumenting Distributed, here we setup the
+  ## Distributed functions to identify resources
+  FFI.Extrae_set_numtasks_function(dist_numtasks)
+  FFI.Extrae_set_taskid_function(dist_taskid)
+
+  ## Setup traceid for not intereference
+  name = "JULIATRACE" * string(Distributed.myid())
+  var = "EXTRAE_PROGRAM_NAME"
+  @ccall setenv(var::Cstring, name::Cstring)::Cint
+
+  FFI.Extrae_init()
+end
 export init
 
 

--- a/src/Instrumentation/Distributed.jl
+++ b/src/Instrumentation/Distributed.jl
@@ -109,17 +109,8 @@ Cassette.posthook(::ExtraeCtx, _, ::typeof(Distributed.handle_msg), args...) = e
 
 
 # resource identification
-function dist_taskid()::Cuint
-    id = Distributed.myid() - 1
-    return id
-end
-export dist_taskid
-
-function dist_numtasks()::Cuint
-    nworkers = Distributed.nworkers() + 1
-    return nworkers
-end
-export dist_numtasks
+dist_taskid()::Cuint = Distributed.myid() - 1
+dist_numtasks()::Cuint = Distributed.nworkers() + 1
 
 # cluster manager addprocs 
 function addprocs_extrae(np::Integer; restrict=true, kwargs...)

--- a/src/Instrumentation/Distributed.jl
+++ b/src/Instrumentation/Distributed.jl
@@ -43,6 +43,16 @@ description(::typeof(DistributedRemoteCallWait)) = "remotecall_wait"
 description(::typeof(DistributedProcessMessages)) = "process_messages"
 description(::typeof(DistributedInterrupt)) = "interrupt"
 
+description(::typeof(DistributedHandleCall)) = "CallMsg{:call}"
+description(::typeof(DistributedHandleCallFetch)) = "CallMsg{:call_fetch}"
+description(::typeof(DistributedHandleCallWait)) = "CallWaitMsg"
+description(::typeof(DistributedHandleRemoteDo)) = "RemoteDoMsg"
+description(::typeof(DistributedHandleResult)) = "ResultMsg"
+description(::typeof(DistributedHandleIdentifySocket)) = "IdentifySocketMsg"
+description(::typeof(DistributedHandleIdentifySocketAck)) = "IdentifySocketAckMsg"
+description(::typeof(DistributedHandleJoinPGRP)) = "JoinPGRPMsg"
+description(::typeof(DistributedHandleJoinComplete)) = "JoinCompletesg"
+
 description(::typeof(DistributedUsefulWork)) = "Useful"
 description(::typeof(DistributedNotUsefulWork)) = "Not Useful"
 

--- a/src/Instrumentation/Distributed.jl
+++ b/src/Instrumentation/Distributed.jl
@@ -38,7 +38,7 @@ end
 export dist_taskid
 
 function dist_numtasks()::Cuint
-    nworkers = Distributed.nworkers()
+    nworkers = Distributed.nworkers() + 1
     return nworkers
 end
 export dist_numtasks

--- a/src/Instrumentation/Distributed.jl
+++ b/src/Instrumentation/Distributed.jl
@@ -1,5 +1,7 @@
 using Distributed
 
+include("ExtraeLocalManager.jl")
+
 # worker management
 Cassette.prehook(::ExtraeCtx, ::typeof(addprocs), args...) = println("[TRACE] addprocs - begin @ $(myid())")
 Cassette.posthook(::ExtraeCtx, _, ::typeof(addprocs), args...) = println("[TRACE] addprocs - end @ $(myid())")
@@ -42,3 +44,11 @@ function dist_numtasks()::Cuint
     return nworkers
 end
 export dist_numtasks
+
+# cluster manager addprocs 
+function addprocs_extrae(np::Integer; restrict=true, kwargs...)
+    manager = Extrae.ExtraeLocalManager(np, restrict)
+    #check_addprocs_args(manager, kwargs)
+    addprocs(manager; kwargs...)
+end
+export addprocs_extrae

--- a/src/Instrumentation/Distributed.jl
+++ b/src/Instrumentation/Distributed.jl
@@ -29,3 +29,16 @@ Cassette.posthook(::ExtraeCtx, _, ::typeof(process_messages), args...) = println
 
 Cassette.prehook(::ExtraeCtx, ::typeof(interrupt), args...) = println("[TRACE] interrupt - begin @ $(myid())")
 Cassette.posthook(::ExtraeCtx, _, ::typeof(interrupt), args...) = println("[TRACE] interrupt - end @ $(myid())")
+
+# resource identification
+function dist_taskid()::Cuint
+    id = Distributed.myid() - 1
+    return id
+end
+export dist_taskid
+
+function dist_numtasks()::Cuint
+    nworkers = Distributed.nworkers()
+    return nworkers
+end
+export dist_numtasks

--- a/src/Instrumentation/ExtraeLocalManager.jl
+++ b/src/Instrumentation/ExtraeLocalManager.jl
@@ -20,7 +20,13 @@ function Distributed.launch(manager::ExtraeLocalManager, params::Dict, launched:
     cookie = cluster_cookie()
 
     #hookline = """using Distributed; f = Base.open("hooked.txt", "w"); write(f, $(repr(string(cookie))))"""
-    hookline = """using Distributed; using Extrae; using Cassette; Cassette.overdub(Extrae.ExtraeCtx(), start_worker, $(repr(string(cookie))))"""
+    hookline = """
+        using Distributed
+        using Extrae
+        using Cassette
+        
+        Cassette.overdub(Extrae.ExtraeCtx(), start_worker, $(repr(string(cookie))))
+        """
 
 
     # Bug: Instead of using julia_cmd(exename), I directly use exename because idk howto access Base.julia_cmd

--- a/src/Instrumentation/ExtraeLocalManager.jl
+++ b/src/Instrumentation/ExtraeLocalManager.jl
@@ -1,0 +1,55 @@
+"""
+ExtraeLocalManager.jl
+Implements a copy of the default LocalClusterManager that starts
+workers with an overdubbed event loop.
+
+"""
+
+struct ExtraeLocalManager <: ClusterManager
+    np::Int
+    restrict::Bool  # Restrict binding to 127.0.0.1 only
+end
+
+Base.show(io::IO, manager::ExtraeLocalManager) = print(io, "ExtraeLocalManager()")
+
+function Distributed.launch(manager::ExtraeLocalManager, params::Dict, launched::Array, c::Condition)
+    dir = params[:dir]
+    exename = params[:exename]
+    exeflags = params[:exeflags]
+    bind_to = manager.restrict ? `127.0.0.1` : `$(LPROC.bind_addr)`
+    cookie = cluster_cookie()
+
+    #hookline = """using Distributed; f = Base.open("hooked.txt", "w"); write(f, $(repr(string(cookie))))"""
+    hookline = """using Distributed; using Extrae; using Cassette; Cassette.overdub(Extrae.ExtraeCtx(), start_worker, $(repr(string(cookie))))"""
+
+
+    # Bug: Instead of using julia_cmd(exename), I directly use exename because idk howto access Base.julia_cmd
+    for i in 1:manager.np
+        cmd = `env EXTRAE_SKIP_AUTO_LIBRARY_INITIALIZE=1 $exename $exeflags --project=. --bind-to $bind_to -e $hookline`
+        io = open(detach(setenv(cmd, dir=dir)), "r+")
+        
+        # Cluster cookie is not passed through IO. Instead, we set it 
+        # as a parameter when starting worker, through the hookline
+        #Distributed.write_cookie(io)
+
+        wconfig = WorkerConfig()
+        wconfig.process = io
+        wconfig.io = io.out
+        wconfig.enable_threaded_blas = params[:enable_threaded_blas]
+        push!(launched, wconfig)
+    end
+
+    notify(c)
+end
+
+function Distributed.manage(manager::ExtraeLocalManager, id::Integer, config::WorkerConfig, op::Symbol)
+    if op === :interrupt
+        kill(config.process, 2)
+    end
+end
+
+export launch
+
+export manage
+
+export ExtraeLocalManager

--- a/src/Instrumentation/ExtraeLocalManager.jl
+++ b/src/Instrumentation/ExtraeLocalManager.jl
@@ -1,8 +1,8 @@
 """
-ExtraeLocalManager.jl
-Implements a copy of the default LocalClusterManager that starts
-workers with an overdubbed event loop.
+    ExtraeLocalManager.jl
 
+Implements a copy of the default `LocalClusterManager` that starts
+workers with an overdubbed event loop.
 """
 
 struct ExtraeLocalManager <: ClusterManager
@@ -19,15 +19,13 @@ function Distributed.launch(manager::ExtraeLocalManager, params::Dict, launched:
     bind_to = manager.restrict ? `127.0.0.1` : `$(LPROC.bind_addr)`
     cookie = cluster_cookie()
 
-    #hookline = """using Distributed; f = Base.open("hooked.txt", "w"); write(f, $(repr(string(cookie))))"""
     hookline = """
         using Distributed
         using Extrae
         using Cassette
         
-        Cassette.overdub(Extrae.ExtraeCtx(), start_worker, $(repr(string(cookie))))
+        Cassette.overdub(Extrae.ExtraeCtx(), start_worker, $(repr(cookie)))
         """
-
 
     # Bug: Instead of using julia_cmd(exename), I directly use exename because idk howto access Base.julia_cmd
     for i in 1:manager.np

--- a/src/Instrumentation/ExtraeLocalManager.jl
+++ b/src/Instrumentation/ExtraeLocalManager.jl
@@ -48,8 +48,4 @@ function Distributed.manage(manager::ExtraeLocalManager, id::Integer, config::Wo
     end
 end
 
-export launch
-
-export manage
-
 export ExtraeLocalManager

--- a/src/Instrumentation/ExtraeLocalManager.jl
+++ b/src/Instrumentation/ExtraeLocalManager.jl
@@ -10,7 +10,7 @@ struct ExtraeLocalManager <: ClusterManager
     restrict::Bool  # Restrict binding to 127.0.0.1 only
 end
 
-Base.show(io::IO, manager::ExtraeLocalManager) = print(io, "ExtraeLocalManager()")
+Base.show(io::IO, manager::ExtraeLocalManager) = print(io, "ExtraeLocalManager(#procs=$(manager.np), restrict=$(manager.restrict))")
 
 function Distributed.launch(manager::ExtraeLocalManager, params::Dict, launched::Array, c::Condition)
     dir = params[:dir]

--- a/src/Instrumentation/ExtraeLocalManager.jl
+++ b/src/Instrumentation/ExtraeLocalManager.jl
@@ -25,7 +25,7 @@ function Distributed.launch(manager::ExtraeLocalManager, params::Dict, launched:
 
     # Bug: Instead of using julia_cmd(exename), I directly use exename because idk howto access Base.julia_cmd
     for i in 1:manager.np
-        cmd = `env EXTRAE_SKIP_AUTO_LIBRARY_INITIALIZE=1 $exename $exeflags --project=. --bind-to $bind_to -e $hookline`
+        cmd = `env EXTRAE_SKIP_AUTO_LIBRARY_INITIALIZE=1 $exename $exeflags --project=. --bind-to $bind_to -e "$hookline"`
         io = open(detach(setenv(cmd, dir=dir)), "r+")
         
         # Cluster cookie is not passed through IO. Instead, we set it 

--- a/test/test-distributed-work.jl
+++ b/test/test-distributed-work.jl
@@ -1,0 +1,27 @@
+using Distributed
+using Extrae
+
+addprocs_extrae(1)
+
+@everywhere using Cassette
+@everywhere using Extrae
+
+
+function random_sleep()
+    println("Worker started: ", myid())
+    sleep(rand((1,2,3,4,5)))
+    println("Worker woke up: ", myid())
+end
+
+function test_distributed_work()
+    @everywhere Extrae.init()
+    Cassette.overdub(Extrae.ExtraeCtx(), remote_do, Cassette.overdub, 2, Extrae.ExtraeCtx(), random_sleep)
+    # Cassette.overdub(Extrae.ExtraeCtx(), remote_do, Cassette.overdub, 3, Extrae.ExtraeCtx(), random_sleep)
+    # Cassette.overdub(Extrae.ExtraeCtx(), remote_do, Cassette.overdub, 4, Extrae.ExtraeCtx(), random_sleep)
+    sleep(10)
+    @everywhere Extrae.finish()
+end
+
+test_distributed_work()
+
+println("END TEST")


### PR DESCRIPTION
This PR adds the functionality to start workers that overdub the runtime's main event loop with a custom `addprocs_extrae` function.